### PR TITLE
Updated UP checks to allow for checks

### DIFF
--- a/check_haproxy.rb
+++ b/check_haproxy.rb
@@ -180,7 +180,7 @@ haproxy_response(options).each do |line|
       exit_code = WARNING if exit_code == OK || exit_code == UNKNOWN
     end
 
-    if row['status'] != 'OPEN' && row['status'] != 'UP'
+    if row['status'] != 'OPEN' && row['status'].exclude? 'UP'
       @errors << message
       exit_code = CRITICAL
     end
@@ -193,7 +193,7 @@ haproxy_response(options).each do |line|
     current_sessions = row['scur'].to_i
     @perfdata << "#{perf_id}_sessions=#{current_sessions};;;;"
     @perfdata << "#{perf_id}_rate=#{row['rate']};;;;#{row['rate_max']}"
-    if row['status'] != 'OPEN' && row['status'] != 'UP'
+    if row['status'] != 'OPEN' && row['status'].exclude? 'UP'
       @errors << message
       exit_code = CRITICAL
     end
@@ -201,7 +201,7 @@ haproxy_response(options).each do |line|
   elsif row['status'] != 'no check'
     @proxies << message
 
-    if row['status'] != 'UP'
+    if row['status'].exclude? 'UP'
       @errors << message
       exit_code = WARNING if exit_code == OK || exit_code == UNKNOWN
     else


### PR DESCRIPTION
We have found that when you have `check` and `fall` enabled like so:
`server some-domain-here 123.123.123.123:43 send-proxy check inter 5s fall 3 rise 5`

The `status` column can be either `UP` OR `UP X/Y` where `Y` is `fall` and `X` is the number unsuccessful health checks. This means that `if row['status'] != 'OPEN' && row['status'] != 'UP'` will throw a critical if its a soft warning (`UP 1/3`).

I have updated the logic to check if the `status` contains `UP` rather than being equal to it. This means you can have soft warnings without a critical, and have the real critical when it transitions to `DOWN`.